### PR TITLE
Move `ipsec.secrets` to `/config` so that it can be easily preserved between rebuilds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,14 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* # cache busted 20160406.1
 
 RUN rm /etc/ipsec.secrets
+RUN mkdir /config
+RUN (cd /etc && ln -s /config/ipsec.secrets .)
 
 ADD ./etc/* /etc/
 ADD ./bin/* /usr/bin/
 
 VOLUME /etc
+VOLUME /config
 
 # http://blogs.technet.com/b/rrasblog/archive/2006/06/14/which-ports-to-unblock-for-vpn-traffic-to-pass-through.aspx
 EXPOSE 500/udp 4500/udp


### PR DESCRIPTION
So I pulled the latest version of this image and rebuilt my container and _poof_ my PSK was gone and I had to reconfigure all my clients, so to save myself the trouble I symlinked it into `/config` and made it a volume so that it can be easily re-used.
