### PR TITLE
Add support for windows clients

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get -y upgrade \
-    && DEBIAN_FRONTEND=noninteractive apt-get -y install strongswan iptables uuid-runtime ndppd openssl \
+    && DEBIAN_FRONTEND=noninteractive apt-get -y install strongswan strongswan-plugin-eap-mschapv2 iptables uuid-runtime ndppd openssl \
     && rm -rf /var/lib/apt/lists/* # cache busted 20160406.1
 
 RUN rm /etc/ipsec.secrets

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get -y upgrade \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:14.04
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get -y upgrade \

--- a/bin/generate-mobileconfig
+++ b/bin/generate-mobileconfig
@@ -38,7 +38,7 @@
 : ${CONN_UUID=$(uuidgen)}
 : ${CONN_HOST=${HOST}}
 : ${CONN_REMOTE_IDENTIFIER=${HOST}}
-CONN_SHARED_SECRET=$(cat /etc/ipsec.secrets | sed 's/.*"\(.*\)"/\1/g')
+CONN_SHARED_SECRET=$(cat /etc/ipsec.secrets | grep PSK | sed 's/.*"\(.*\)"/\1/g')
 
 cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>

--- a/bin/start-vpn
+++ b/bin/start-vpn
@@ -70,7 +70,7 @@ iptables -t nat -A POSTROUTING -s 10.8.0.0/16 -o eth0 -m policy --dir out --pol 
 iptables -t nat -A POSTROUTING -s 10.8.0.0/16 -o eth0 -j MASQUERADE
 
 # hotfix for openssl `unable to write 'random state'` stderr
-SHARED_SECRET="123$(openssl rand -base64 32 2>/dev/null)"
+SHARED_SECRET=${SHARED_SECRET:-$(openssl rand -base64 32 2>/dev/null)}
 [ -f /etc/ipsec.secrets ] || echo ": PSK \"${SHARED_SECRET}\"" > /etc/ipsec.secrets
 
 # configure for windows clients 

--- a/bin/start-vpn
+++ b/bin/start-vpn
@@ -66,11 +66,8 @@ function generate-certs() {
 # Continue reading: https://wiki.strongswan.org/projects/strongswan/wiki/VirtualIP
 sysctl net.ipv4.ip_forward=1
 sysctl net.ipv6.conf.all.forwarding=1
-sysctl net.ipv6.conf.eth0.proxy_ndp=1
 iptables -t nat -A POSTROUTING -s 10.8.0.0/16 -o eth0 -m policy --dir out --pol ipsec -j ACCEPT
 iptables -t nat -A POSTROUTING -s 10.8.0.0/16 -o eth0 -j MASQUERADE
-ip6tables -t nat -A POSTROUTING -s 2a00:1450:400c:c05::/64 -o eth0 -m policy --dir out --pol ipsec -j ACCEPT
-ip6tables -t nat -A POSTROUTING -s 2a00:1450:400c:c05::/64 -o eth0 -j MASQUERADE
 
 # hotfix for openssl `unable to write 'random state'` stderr
 SHARED_SECRET="123$(openssl rand -base64 32 2>/dev/null)"
@@ -112,6 +109,5 @@ fi
 # hotfix for https://github.com/gaomd/docker-ikev2-vpn-server/issues/7
 rm -f /var/run/starter.charon.pid
 
-service ndppd start
 # http://wiki.loopop.net/doku.php?id=server:vpn:strongswanonopenvz
 /usr/sbin/ipsec start --nofork

--- a/bin/start-vpn
+++ b/bin/start-vpn
@@ -22,6 +22,46 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+# https://gist.github.com/losisli/11081793
+function generate-certs() {
+	CN=$1
+
+	# root cert
+	ipsec pki --gen --outform pem > /etc/ipsec.d/private/caKey.pem
+	ipsec pki --self --in /etc/ipsec.d/private/caKey.pem \
+		--dn "C=CN, O=strongSwan, CN=strongSwan CA" \
+		--ca --outform pem > /etc/ipsec.d/cacerts/caCert.pem
+
+	# server cert
+	ipsec pki --gen --outform pem > /etc/ipsec.d/private/serverKey.pem
+	ipsec pki --pub --in /etc/ipsec.d/private/serverKey.pem | ipsec pki --issue \
+		--cacert /etc/ipsec.d/cacerts/caCert.pem \
+		--cakey /etc/ipsec.d/private/caKey.pem \
+		--dn "C=CN, O=strongSwan, CN=$CN" --san="$CN" \
+		--flag serverAuth --flag ikeIntermediate \
+		--outform pem > /etc/ipsec.d/certs/serverCert.pem
+	openssl pkcs12 -export -inkey /etc/ipsec.d/private/serverKey.pem \
+		-in /etc/ipsec.d/certs/serverCert.pem -name "server" \
+		-certfile /etc/ipsec.d/cacerts/caCert.pem \
+		-caname "strongSwan CA" \
+		-password pass: \
+		-out /etc/ipsec.d/certs/serverCert.p12
+
+	# client cert
+	ipsec pki --gen --outform pem > /etc/ipsec.d/private/clientKey.pem
+	ipsec pki --pub --in /etc/ipsec.d/private/clientKey.pem | ipsec pki --issue \
+		--cacert /etc/ipsec.d/cacerts/caCert.pem \
+		--cakey /etc/ipsec.d/private/caKey.pem \
+		--dn "C=CN, O=strongSwan, CN=client" \
+		--outform pem > /etc/ipsec.d/certs/clientCert.pem
+	openssl pkcs12 -export -inkey /etc/ipsec.d/private/clientKey.pem \
+		-in /etc/ipsec.d/certs/clientCert.pem -name "client" \
+		-certfile /etc/ipsec.d/cacerts/caCert.pem \
+		-caname "strongSwan CA" \
+		-password pass: \
+		-out /etc/ipsec.d/certs/clientCert.p12
+}
+
 # https://wiki.strongswan.org/projects/strongswan/wiki/ForwardingAndSplitTunneling
 # Continue reading: https://wiki.strongswan.org/projects/strongswan/wiki/VirtualIP
 sysctl net.ipv4.ip_forward=1
@@ -35,6 +75,39 @@ ip6tables -t nat -A POSTROUTING -s 2a00:1450:400c:c05::/64 -o eth0 -j MASQUERADE
 # hotfix for openssl `unable to write 'random state'` stderr
 SHARED_SECRET="123$(openssl rand -base64 32 2>/dev/null)"
 [ -f /etc/ipsec.secrets ] || echo ": PSK \"${SHARED_SECRET}\"" > /etc/ipsec.secrets
+
+# configure for windows clients 
+if [ -n "$CERT_CN" ] && [ ! -f /etc/ipsec.d/certs/serverCert.pem ]; then
+	generate-certs $CERT_CN
+	cat >> /etc/ipsec.conf <<EOF
+
+conn win
+    keyexchange=ikev2
+    ike=aes256-sha1-modp1024!
+    esp=aes256-sha1!
+    dpdaction=clear
+    dpddelay=300s
+    rekey=no
+    left=%defaultroute
+    leftauth=pubkey
+    leftsubnet=0.0.0.0/0
+    leftcert=serverCert.pem
+    leftid="C=CN, O=strongSwan, CN=$CERT_CN"
+    right=%any
+    rightauth=eap-mschapv2
+    rightsourceip=10.8.0.0/16
+    rightsendcert=never
+    eap_identity=%any
+    auto=add
+EOF
+	VPN_USER=${VPN_USER:-vpnuser}
+	VPN_PASSWORD=${VPN_PASSWORD:-$(openssl rand -base64 32 2>/dev/null)}
+    cat >> /etc/ipsec.secrets <<EOF
+
+: RSA serverKey.pem
+$VPN_USER : EAP 	"$VPN_PASSWORD"
+EOF
+fi
 
 # hotfix for https://github.com/gaomd/docker-ikev2-vpn-server/issues/7
 rm -f /var/run/starter.charon.pid

--- a/etc/ipsec.conf
+++ b/etc/ipsec.conf
@@ -16,9 +16,9 @@ conn %default
 conn rw
     # http://wiki.loopop.net/doku.php?id=server:vpn:strongswanonopenvz
     # https://wiki.strongswan.org/projects/strongswan/wiki/ForwardingAndSplitTunneling
-    leftsubnet=0.0.0.0/0,::/0
+    leftsubnet=0.0.0.0/0
     # end ref
     leftfirewall=yes
     right=%any
-    rightsourceip=10.8.0.0/16,fd6a:6ce3:c8d8:7caa::/64
+    rightsourceip=10.8.0.0/16
     auto=add

--- a/etc/ndppd.conf
+++ b/etc/ndppd.conf
@@ -1,6 +1,0 @@
-proxy eth0 {
-    rule fd6a:6ce3:c8d8:7caa::/64 {
-        static
-    }
-
-}


### PR DESCRIPTION
Reference: https://gist.github.com/losisli/11081793

Usage:

add `-e CERT_CN=<public ip or domain>` option to `docker run` command from the README.
