### PR TITLE
Adding docker-cloud.yaml

### DIFF
--- a/docker-cloud.yaml
+++ b/docker-cloud.yaml
@@ -1,0 +1,15 @@
+ikev2-vpn-mobileconfig:
+  command: generate-mobileconfig
+  environment:
+    - HOST=** inset hostname here **
+  image: 'gaomd/ikev2-vpn-server:latest'
+  privileged: true
+  volumes_from:
+    - ikev2-vpn-server
+ikev2-vpn-server:
+  image: 'gaomd/ikev2-vpn-server:latest'
+  ports:
+    - '500:500/udp'
+    - '4500:4500/udp'
+  privileged: true
+  restart: always


### PR DESCRIPTION
Easier starts VPN with Docker Cloud. Two containers are needed. You can copy mobileconfig content from first container (will be killed after run), second are server instance