### PR TITLE
generate-mobileconfig: Disconnect from VPN while connected to local network

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Recipe to build [`gaomd/ikev2-vpn-server`](https://registry.hub.docker.com/u/gao
 
 ### 2. Generate the .mobileconfig (for iOS / macOS)
 
-    docker run --privileged -i -t --rm --volumes-from ikev2-vpn-server -e "HOST=vpn1.example.com" gaomd/ikev2-vpn-server:0.3.0 generate-mobileconfig > ikev2-vpn.mobileconfig
+    docker run --privileged -i -t --rm --volumes-from ikev2-vpn-server -e "HOST=vpn1.example.com" -e "LOCAL_SSID=myHomeWifi" gaomd/ikev2-vpn-server:0.3.0 generate-mobileconfig > ikev2-vpn.mobileconfig
 
-*Be sure to replace `vpn1.example.com` with your own domain name and resolve it to you server's IP address. Simply put an IP address is supported as well (and enjoy an even faster handshake speed).*
+*Be sure to replace `vpn1.example.com` with your own domain name and resolve it to you server's IP address. Simply put an IP address is supported as well (and enjoy an even faster handshake speed). Also replace `myHomeWifi` with the SSID of your WiFi to disable VPN while connected to your local network. Or remove the LOCAL_SSID environment variable to disable this behavior.*
 
 Transfer the generated `ikev2-vpn.mobileconfig` file to your local computer via SSH tunnel (`scp`) or any other secure methods.
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Recipe to build [`gaomd/ikev2-vpn-server`](https://registry.hub.docker.com/u/gao
 
 ### 2. Generate the .mobileconfig (for iOS / macOS)
 
-    docker run --privileged -i -t --rm --volumes-from ikev2-vpn-server -e "HOST=vpn1.example.com" -e "LOCAL_SSID=myHomeWifi" gaomd/ikev2-vpn-server:0.3.0 generate-mobileconfig > ikev2-vpn.mobileconfig
+    docker run --privileged -i -t --rm --volumes-from ikev2-vpn-server -e "HOST=vpn1.example.com" -e "EXCLUDE_SSID=myHomeWifi" gaomd/ikev2-vpn-server:0.3.0 generate-mobileconfig > ikev2-vpn.mobileconfig
 
-*Be sure to replace `vpn1.example.com` with your own domain name and resolve it to you server's IP address. Simply put an IP address is supported as well (and enjoy an even faster handshake speed). Also replace `myHomeWifi` with the SSID of your WiFi to disable VPN while connected to your local network. Or remove the LOCAL_SSID environment variable to disable this behavior.*
+*Be sure to replace `vpn1.example.com` with your own domain name and resolve it to you server's IP address. Simply put an IP address is supported as well (and enjoy an even faster handshake speed). Also replace `myHomeWifi` with the SSID of your WiFi to disable VPN while connected to your local network. Or remove the EXCLUDE_SSID environment variable to disable this behavior.*
 
 Transfer the generated `ikev2-vpn.mobileconfig` file to your local computer via SSH tunnel (`scp`) or any other secure methods.
 

--- a/bin/generate-mobileconfig
+++ b/bin/generate-mobileconfig
@@ -40,6 +40,8 @@
 : ${CONN_REMOTE_IDENTIFIER=${HOST}}
 CONN_SHARED_SECRET=$(cat /etc/ipsec.secrets | sed 's/.*"\(.*\)"/\1/g')
 
+LOCAL_SSID=${LOCAL_SSID:-""}
+
 cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -102,6 +104,14 @@ cat <<EOF
                     <integer>1</integer>
                     <key>OnDemandRules</key>
                     <array>
+			<dict>
+			    <key>Action</key>
+			    <string>Disconnect</string>
+			    <key>SSIDMatch</key>
+			    <array>
+				<string>${LOCAL_SSID}</string>
+			    </array>
+			</dict>
                         <dict>
                             <key>Action</key>
                             <string>Connect</string>

--- a/bin/generate-mobileconfig
+++ b/bin/generate-mobileconfig
@@ -40,7 +40,7 @@
 : ${CONN_REMOTE_IDENTIFIER=${HOST}}
 CONN_SHARED_SECRET=$(cat /etc/ipsec.secrets | sed 's/.*"\(.*\)"/\1/g')
 
-LOCAL_SSID=${LOCAL_SSID:-""}
+EXCLUDE_SSID=${EXCLUDE_SSID:-""}
 
 cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
@@ -109,7 +109,7 @@ cat <<EOF
 			    <string>Disconnect</string>
 			    <key>SSIDMatch</key>
 			    <array>
-				<string>${LOCAL_SSID}</string>
+				<string>${EXCLUDE_SSID}</string>
 			    </array>
 			</dict>
                         <dict>


### PR DESCRIPTION
This PR allows to supply a optional EXCLUDE_SSID environment variable when generating the mobileconfig file. If set, the device will disconnect from VPN while connected to the specified WiFi SSID. This is useful when you are at home and your device is connected to the local network. Still being connected to the VPN that tunnels to your local network anyway makes no sense and lowers your connection speed. As soon as you disconnect from the specified SSID, the VPN connection will be established again.

If no EXCLUDE_SSID is provided, the profile behaves as before.

The mobileconfig-parts are taken from a profile generated using the Apple Configurator 2 and tested on macOS 10.12, iOS 10 and iOS 11 PB 2 but should also work on previous releases since IKEv2 is supported.