### PR TITLE
More documentation / changes for supporting virtual IP on LAN network.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get -y upgrade \
-    && DEBIAN_FRONTEND=noninteractive apt-get -y install strongswan iptables uuid-runtime ndppd openssl \
+    && DEBIAN_FRONTEND=noninteractive apt-get -y install strongswan strongswan-plugin-farp strongswan-plugin-dhcp iptables uuid-runtime ndppd openssl \
     && rm -rf /var/lib/apt/lists/* # cache busted 20160406.1
 
 RUN rm /etc/ipsec.secrets

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IKEv2 VPN Server on Docker
 
-Recipe to build [`gaomd/ikev2-vpn-server`](https://registry.hub.docker.com/u/gaomd/ikev2-vpn-server/) Docker image.
+Recipe to build, clone this repo and run `docker build . -t "testing/ikev2-vpn-server"`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Recipe to build [`gaomd/ikev2-vpn-server`](https://registry.hub.docker.com/u/gao
 
 ## Usage
 
-### 1. Start the IKEv2 VPN Server
+#### For using iTunes Home Sharing / Plex Shareing connect directly to your LAN network
+
+### 1. Start the IKEv2 VPN Server (the -p options are outdated for utalizing Bonjour, bridge directly to LAN)
 
     docker run --privileged -d --name ikev2-vpn-server --restart=always -p 500:500/udp -p 4500:4500/udp gaomd/ikev2-vpn-server:0.3.0
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Recipe to build, clone this repo and run `docker build . -t "testing/ikev2-vpn-s
 
 ### 1. Start the IKEv2 VPN Server (the -p options are outdated for utalizing Bonjour, bridge directly to LAN)
 
-    docker run --privileged -d --name ikev2-vpn-server --restart=always -p 500:500/udp -p 4500:4500/udp gaomd/ikev2-vpn-server:0.3.0
+    docker run --privileged -d --name ikev2-vpn-server --restart=always -p 500:500/udp -p 4500:4500/udp testing/ikev2-vpn-server:latest
 
 ### 2. Generate the .mobileconfig (for iOS / macOS)
 
-    docker run --privileged -i -t --rm --volumes-from ikev2-vpn-server -e "HOST=vpn1.example.com" gaomd/ikev2-vpn-server:0.3.0 generate-mobileconfig > ikev2-vpn.mobileconfig
+    docker run --privileged -i -t --rm --volumes-from ikev2-vpn-server -e "HOST=vpn1.example.com" testing/ikev2-vpn-server:latest generate-mobileconfig > ikev2-vpn.mobileconfig
 
 *Be sure to replace `vpn1.example.com` with your own domain name and resolve it to you server's IP address. Simply put an IP address is supported as well (and enjoy an even faster handshake speed).*
 

--- a/etc/ipsec.conf
+++ b/etc/ipsec.conf
@@ -22,3 +22,4 @@ conn rw
     right=%any
     rightsourceip=%dhcp
     auto=add
+    esp=aes256-sha256-modp2048

--- a/etc/ipsec.conf
+++ b/etc/ipsec.conf
@@ -20,5 +20,5 @@ conn rw
     # end ref
     leftfirewall=yes
     right=%any
-    rightsourceip=10.8.0.0/16,fd6a:6ce3:c8d8:7caa::/64
+    rightsourceip=%dhcp
     auto=add


### PR DESCRIPTION
These are changes so users can start a docker container on their local LAN network, this allows Plex GDM (“G'Day Mate” discovery) and Bonjour for Apple HomeSharing features.

Also pulled changes in for: https://github.com/gaomd/docker-ikev2-vpn-server/pull/42